### PR TITLE
bug  isNaNF64UI isNaNF32UI not resolved-fix

### DIFF
--- a/uspike/spike_link.h
+++ b/uspike/spike_link.h
@@ -5,6 +5,7 @@
 #include "trap.h"
 #include "arith.h"
 #include "processor.h"
+#include "internals.h"
 
 #undef MMU
 #undef set_pc


### PR DESCRIPTION
while building I encountered e build error that sNaNF64UI isNaNF32UI  were not resolved in fmax and fmin_d.cc.
this resolves it